### PR TITLE
Map Polyline Patterns

### DIFF
--- a/lib/Maui.GoogleMaps/Logics/DefaultPolylineLogic.cs
+++ b/lib/Maui.GoogleMaps/Logics/DefaultPolylineLogic.cs
@@ -9,7 +9,6 @@ internal abstract class DefaultPolylineLogic<TNative, TNativeMap> : DefaultLogic
     protected override void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)
     {
         base.OnItemPropertyChanged(sender, e);
-        
         if (sender is not Polyline { NativeObject: TNative nativeItem } outerItem)
         {
             return;
@@ -19,6 +18,8 @@ internal abstract class DefaultPolylineLogic<TNative, TNativeMap> : DefaultLogic
         else if (e.PropertyName == Polyline.StrokeColorProperty.PropertyName) OnUpdateStrokeColor(outerItem, nativeItem);
         else if (e.PropertyName == Polyline.StrokeWidthProperty.PropertyName) OnUpdateStrokeWidth(outerItem, nativeItem);
         else if (e.PropertyName == Polyline.ZIndexProperty.PropertyName) OnUpdateZIndex(outerItem, nativeItem);
+        else if (e.PropertyName == Polyline.StrokePatternProperty.PropertyName) OnUpdateLinePattern(outerItem, nativeItem);
+
     }
 
     protected override void CheckCanCreateNativeItem(Polyline outerItem)
@@ -33,4 +34,5 @@ internal abstract class DefaultPolylineLogic<TNative, TNativeMap> : DefaultLogic
     internal abstract void OnUpdateStrokeColor(Polyline outerItem, TNative nativeItem);
     internal abstract void OnUpdateStrokeWidth(Polyline outerItem, TNative nativeItem);
     internal abstract void OnUpdateZIndex(Polyline outerItem, TNative nativeItem);
+    internal abstract void OnUpdateLinePattern(Polyline outerItem, TNative nativeItem);
 }

--- a/lib/Maui.GoogleMaps/Platforms/Android/Logics/PolylineLogic.cs
+++ b/lib/Maui.GoogleMaps/Platforms/Android/Logics/PolylineLogic.cs
@@ -3,6 +3,7 @@ using Android.Gms.Maps.Model;
 using Maui.GoogleMaps.Android;
 using Microsoft.Maui.Controls.Compatibility.Platform.Android;
 using NativePolyline = Android.Gms.Maps.Model.Polyline;
+using NativePatternItem = Android.Gms.Maps.Model.PatternItem;
 
 namespace Maui.GoogleMaps.Logics.Android;
 
@@ -41,6 +42,7 @@ internal class PolylineLogic : DefaultPolylineLogic<NativePolyline, GoogleMap>
         opts.InvokeColor(outerItem.StrokeColor.ToAndroid());
         opts.Clickable(outerItem.IsClickable);
         opts.InvokeZIndex(outerItem.ZIndex);
+        opts.InvokePattern(GenerateLinePattern(outerItem.StrokePattern));
 
         var nativePolyline = NativeMap.AddPolyline(opts);
 
@@ -100,5 +102,20 @@ internal class PolylineLogic : DefaultPolylineLogic<NativePolyline, GoogleMap>
     internal override void OnUpdateZIndex(Polyline outerItem, NativePolyline nativeItem)
     {
         nativeItem.ZIndex = outerItem.ZIndex;
+    }
+
+    internal override void OnUpdateLinePattern(Polyline outerItem, NativePolyline nativeItem)
+    {
+        nativeItem.Pattern = GenerateLinePattern(outerItem.StrokePattern);
+    }
+
+    internal List<NativePatternItem> GenerateLinePattern(LinePattern pattern)
+    {
+        if (pattern == null || pattern.Type == LineTypes.Straight)
+            return null;
+        else if (pattern.Type == LineTypes.Dashed)
+            return new List<NativePatternItem>() { new Dash(pattern.DashWidth), new Gap(pattern.GapWidth), new Dash(pattern.DashWidth) };
+        else
+            return new List<NativePatternItem>() { new Dot(), new Gap(pattern.GapWidth), new Dot() };
     }
 }

--- a/lib/Maui.GoogleMaps/Polyline.cs
+++ b/lib/Maui.GoogleMaps/Polyline.cs
@@ -9,6 +9,7 @@ public sealed class Polyline : BindableObject
     public static readonly BindableProperty StrokeColorProperty = BindableProperty.Create(nameof(StrokeColor), typeof(Color), typeof(Polyline), Colors.Blue);
     public static readonly BindableProperty IsClickableProperty = BindableProperty.Create(nameof(IsClickable), typeof(bool), typeof(Polyline), false);
     public static readonly BindableProperty ZIndexProperty = BindableProperty.Create(nameof(ZIndex), typeof(int), typeof(Polyline), 0);
+    public static readonly BindableProperty StrokePatternProperty = BindableProperty.Create(nameof(StrokePattern), typeof(LinePattern), typeof(Polyline), StrokePatternBuilder.SolidLine());
 
     private readonly ObservableCollection<Position> _positions = new ObservableCollection<Position>();
 
@@ -36,6 +37,12 @@ public sealed class Polyline : BindableObject
     {
         get { return (int)GetValue(ZIndexProperty); }
         set { SetValue(ZIndexProperty, value); }
+    }
+
+    public LinePattern StrokePattern
+    {
+        get { return (LinePattern)GetValue(StrokePatternProperty); }
+        set { SetValue(StrokePatternProperty, value); }
     }
 
     public IList<Position> Positions
@@ -82,5 +89,37 @@ public sealed class Polyline : BindableObject
     {
         _positionsChangedHandler?.Invoke(this, e);
     }
+}
+
+public static class StrokePatternBuilder
+{
+    public static LinePattern SolidLine()
+    {
+        return null;
+    }
+
+    public static LinePattern DashedLine(int gapWidth = 10, int dashWidth = 20)
+    {
+        return new LinePattern { Type = LineTypes.Dashed, DashWidth = dashWidth, GapWidth = gapWidth };
+    }
+
+    public static LinePattern DottedLine(int gapWidth = 5, int dashWidth = 50)
+    {
+        return new LinePattern { Type = LineTypes.Dotted, GapWidth = gapWidth, DashWidth = dashWidth };
+    }
+}
+
+public class LinePattern
+{
+    public int Type { get; set; }
+    public int GapWidth { get; set; }
+    public int DashWidth { get; set; }
+}
+
+public static class LineTypes
+{
+    public static int Straight = 0;
+    public static int Dotted = 1;
+    public static int Dashed = 2;
 }
 

--- a/sample/MauiGoogleMapSample/Shapes2Page.xaml.cs
+++ b/sample/MauiGoogleMapSample/Shapes2Page.xaml.cs
@@ -36,6 +36,26 @@ namespace MauiGoogleMapSample
             map.Polylines.Add(CreateShiftedPolyline(polyline1, 0d, 0.05d, Colors.Yellow));
             map.Polylines.Add(CreateShiftedPolyline(polyline1, 0d, 0.10d, Colors.Green));
 
+            //Add Dashed Polyline
+            var polylineDashed = new Polyline();
+            polylineDashed.StrokeWidth = 10f;
+            polylineDashed.StrokeColor = Colors.Green;
+            polylineDashed.Positions.Add(new Position(36.20, 139.83));
+            polylineDashed.Positions.Add(new Position(36.30, 139.93));
+            polylineDashed.Positions.Add(new Position(36.40, 140.03));
+            polylineDashed.StrokePattern = StrokePatternBuilder.DashedLine();
+            map.Polylines.Add(polylineDashed);
+
+            //Add Dotted Polyline (appears as dashed on iOS)
+            var polylineDotted = new Polyline();
+            polylineDotted.StrokeWidth = 10f;
+            polylineDotted.StrokeColor = Colors.Orange;
+            polylineDotted.Positions.Add(new Position(36.50, 139.83));
+            polylineDotted.Positions.Add(new Position(36.60, 139.93));
+            polylineDotted.Positions.Add(new Position(36.70, 140.03));
+            polylineDotted.StrokePattern = StrokePatternBuilder.DottedLine();
+            map.Polylines.Add(polylineDotted);
+
             // Add Circles
             var circle1 = new Circle();
             circle1.StrokeWidth = 10f;
@@ -85,7 +105,6 @@ namespace MauiGoogleMapSample
             var poly = new Polyline();
             poly.StrokeWidth = polyline.StrokeWidth;
             poly.StrokeColor = color;
-
             foreach (var p in polyline.Positions)
             {
                 poly.Positions.Add(new Position(p.Latitude + shiftLat, p.Longitude + shiftLon));
@@ -105,7 +124,5 @@ namespace MauiGoogleMapSample
 
             return cir;
         }
-
-
     }
 }


### PR DESCRIPTION
#43  Ability to allow different patterns on polylines. Android supports dashed and dotted lines in addition to the standard solid. IOS supports dashed lines only at this point. You can specify dash width and gap width to customize appearance of the lines.