### PR TITLE
fixed android/ios obsolete code

### DIFF
--- a/lib/Maui.GoogleMaps/Maui.GoogleMaps.csproj
+++ b/lib/Maui.GoogleMaps/Maui.GoogleMaps.csproj
@@ -9,10 +9,17 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<PackageId>Onion.Maui.GoogleMaps</PackageId>
 		<Title>Maui.GoogleMaps</Title>
-		<PackageVersion>5.1.1</PackageVersion>
+		<PackageVersion>5.1.2</PackageVersion>
 		<PackageReleaseNotes>
+# 5.1.2
+- Fixed android/ios obsolete code, small code cleanings
 # 5.1.1
 - Fixed min/max zoom level mapping for MvvmMapHandler
+# 5.1.0
+- Added MvvmMap control, which has a lot of useful bindings, has support for custom info window.
+- Added ability to allow different patterns on polylines (Android: dashed and dotted lines, iOS: dashed lines only at this point)
+- Fixed snapshots on iOS 17+
+- MAUI update
 		</PackageReleaseNotes>
 		<Authors>themronion</Authors>
 		<Copyright>Copyright 2022-2024</Copyright>

--- a/lib/Maui.GoogleMaps/Platforms/Android/Extensions/ActivityExtensions.cs
+++ b/lib/Maui.GoogleMaps/Platforms/Android/Extensions/ActivityExtensions.cs
@@ -1,14 +1,11 @@
 ﻿using Android.App;
-using Android.Util;
 
 namespace Maui.GoogleMaps.Android.Extensions;
 
 internal static class ActivityExtensions
 {
-    public static float GetScaledDensity(this Activity self) 
+    public static float GetScaledDensity(this Activity self)
     {
-        var metrics = new DisplayMetrics();
-        self.WindowManager.DefaultDisplay.GetMetrics(metrics);
-        return metrics.ScaledDensity;
+        return self.Resources.DisplayMetrics.Density;
     }
 }

--- a/lib/Maui.GoogleMaps/Platforms/Android/Factories/DefaultBitmapDescriptorFactory.cs
+++ b/lib/Maui.GoogleMaps/Platforms/Android/Factories/DefaultBitmapDescriptorFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
+
 using Android.Graphics;
-using Android.Widget;
+
 using AndroidBitmapDescriptor = Android.Gms.Maps.Model.BitmapDescriptor;
 using AndroidBitmapDescriptorFactory = Android.Gms.Maps.Model.BitmapDescriptorFactory;
 
@@ -18,7 +19,7 @@ public sealed class DefaultBitmapDescriptorFactory : IBitmapDescriptorFactory
     private DefaultBitmapDescriptorFactory()
     {
     }
-    
+
     public AndroidBitmapDescriptor ToNative(BitmapDescriptor bitmapDescriptor, IMauiContext mauiContext)
     {
         if (bitmapDescriptor.Id != null && _cacheDictionary.TryGetValue(bitmapDescriptor.Id, out var cachedBitmap))
@@ -61,8 +62,7 @@ public sealed class DefaultBitmapDescriptorFactory : IBitmapDescriptorFactory
 
             case BitmapDescriptorType.View:
                 var iconView = bitmapDescriptor.View.Invoke();
-                var nativeView = Utils.ConvertMauiToNative(iconView, mauiContext);
-                var androidBitmapDescriptor = Utils.ConvertViewToBitmapDescriptor(nativeView);
+                var androidBitmapDescriptor = Utils.ConvertMauiViewToBitmapDescriptor(iconView, mauiContext);
                 return androidBitmapDescriptor;
 
             default:

--- a/lib/Maui.GoogleMaps/Platforms/Android/MapHandler.cs
+++ b/lib/Maui.GoogleMaps/Platforms/Android/MapHandler.cs
@@ -2,6 +2,7 @@
 using Android.Gms.Maps.Model;
 using Android.Graphics;
 using Android.OS;
+
 using Maui.GoogleMaps.Android;
 using Maui.GoogleMaps.Android.Callbacks;
 using Maui.GoogleMaps.Android.Extensions;
@@ -9,6 +10,7 @@ using Maui.GoogleMaps.Internals;
 using Maui.GoogleMaps.Logics;
 using Maui.GoogleMaps.Logics.Android;
 using Maui.GoogleMaps.Platforms.Android.Listeners;
+
 using Math = System.Math;
 
 namespace Maui.GoogleMaps.Handlers;
@@ -71,15 +73,15 @@ public partial class MapHandler
     {
         _cameraLogic = new CameraLogic(UpdateVisibleRegion);
 
-        Logics = new List<BaseLogic<GoogleMap>>
-        {
+        Logics =
+        [
             new PolylineLogic(),
             new PolygonLogic(),
             new CircleLogic(),
             new PinLogic(Config.GetBitmapdescriptionFactory(), OnMarkerCreating, OnMarkerCreated, OnMarkerDeleting, OnMarkerDeleted),
             new TileLayerLogic(),
             new GroundOverlayLogic(Config.GetBitmapdescriptionFactory())
-        };
+        ];
 
         var activity = Platform.CurrentActivity;
 
@@ -229,7 +231,7 @@ public partial class MapHandler
         if (handler.NativeMap != null)
         {
             handler.NativeMap.TrafficEnabled = map.IsTrafficEnabled;
-        }    
+        }
     }
 
     public static void MapIsIndoorEnabled(MapHandler handler, Map map)
@@ -280,7 +282,7 @@ public partial class MapHandler
 
             _uiSettingsLogic.Unregister();
 
-           Map.OnSnapshot -= OnSnapshot;
+            Map.OnSnapshot -= OnSnapshot;
             _cameraLogic.Unregister();
 
             foreach (var logic in Logics)

--- a/lib/Maui.GoogleMaps/Platforms/Android/MvvmMapHandler.cs
+++ b/lib/Maui.GoogleMaps/Platforms/Android/MvvmMapHandler.cs
@@ -62,8 +62,7 @@ public class InfoWindowAdapter : Java.Lang.Object, GoogleMap.IInfoWindowAdapter
 
         var platformView = view.ToPlatform(Map.Handler.MauiContext);
 
-        var request = view.Measure(this.Map.Width - 50, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-        view.Layout(new Rect(0, 0, request.Request.Width, request.Request.Height));
+        var request = view.Measure(this.Map.Width - (int)platformView.Context.ToPixels(20), double.PositiveInfinity, MeasureFlags.IncludeMargins);
 
         platformView.LayoutParameters = new LayoutParams((int)platformView.Context.ToPixels(request.Request.Width), (int)platformView.Context.ToPixels(request.Request.Height));
 

--- a/lib/Maui.GoogleMaps/Platforms/Android/MvvmMapHandler.cs
+++ b/lib/Maui.GoogleMaps/Platforms/Android/MvvmMapHandler.cs
@@ -47,6 +47,11 @@ public class InfoWindowAdapter : Java.Lang.Object, GoogleMap.IInfoWindowAdapter
 
     public virtual global::Android.Views.View GetInfoContents(Marker marker)
     {
+        return null;
+    }
+
+    public virtual global::Android.Views.View GetInfoWindow(Marker marker)
+    {
         var pin = Map.Pins.FirstOrDefault(p => ((Marker)p.NativeObject).Id == marker.Id);
 
         var template = Map.InfoWindowTemplate;
@@ -67,10 +72,5 @@ public class InfoWindowAdapter : Java.Lang.Object, GoogleMap.IInfoWindowAdapter
         platformView.LayoutParameters = new LayoutParams((int)platformView.Context.ToPixels(request.Request.Width), (int)platformView.Context.ToPixels(request.Request.Height));
 
         return platformView;
-    }
-
-    public virtual global::Android.Views.View GetInfoWindow(Marker marker)
-    {
-        return null;
     }
 }

--- a/lib/Maui.GoogleMaps/Platforms/Android/Utils.cs
+++ b/lib/Maui.GoogleMaps/Platforms/Android/Utils.cs
@@ -3,6 +3,7 @@
 
 using Android.Graphics;
 using Android.Views;
+
 using Microsoft.Maui.Platform;
 
 namespace Maui.GoogleMaps.Android;
@@ -13,7 +14,7 @@ public static class Utils
     /// convert from dp to pixels
     /// </summary>
     /// <param name="dp">Dp.</param>
-    public static int DpToPx(float dp)
+    public static int DpToPx(double dp)
     {
         var metrics = global::Android.App.Application.Context.Resources.DisplayMetrics;
         return (int)(dp * metrics.Density);
@@ -40,25 +41,28 @@ public static class Utils
         return nativeView;
     }
 
-    public static Bitmap ConvertViewToBitmap(global::Android.Views.View androidView)
+    public static Bitmap ConvertMauiViewToBitmap(Microsoft.Maui.Controls.View view, IMauiContext mauiContext)
     {
-        androidView.SetLayerType(LayerType.Hardware, null);
-        androidView.DrawingCacheEnabled = true;
+        var androidView = ConvertMauiToNative(view, mauiContext);
 
-        androidView.Measure(
-            global::Android.Views.View.MeasureSpec.MakeMeasureSpec(0, MeasureSpecMode.Unspecified),
-            global::Android.Views.View.MeasureSpec.MakeMeasureSpec(0, MeasureSpecMode.Unspecified));
-        androidView.Layout(0, 0, androidView.MeasuredWidth, androidView.MeasuredHeight);
+        var measure = view.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
 
-        androidView.BuildDrawingCache(true);
-        Bitmap bitmap = Bitmap.CreateBitmap(androidView.GetDrawingCache(true));
-        androidView.DrawingCacheEnabled = false; // clear drawing cache
+        var width = (int)androidView.Context.ToPixels(measure.Request.Width);
+        var height = (int)androidView.Context.ToPixels(measure.Request.Height);
+
+        androidView.Layout(0, 0, width, height);
+
+        Bitmap bitmap = Bitmap.CreateBitmap(width, height, Bitmap.Config.Argb8888);
+
+        var canvas = new Canvas(bitmap);
+        androidView.Draw(canvas);
+
         return bitmap;
     }
 
-    public static global::Android.Gms.Maps.Model.BitmapDescriptor ConvertViewToBitmapDescriptor(global::Android.Views.View androidView)
+    public static global::Android.Gms.Maps.Model.BitmapDescriptor ConvertMauiViewToBitmapDescriptor(Microsoft.Maui.Controls.View view, IMauiContext mauiContext)
     {
-        var bitmap = ConvertViewToBitmap(androidView);
+        var bitmap = ConvertMauiViewToBitmap(view, mauiContext);
         var bitmapDescriptor = global::Android.Gms.Maps.Model.BitmapDescriptorFactory.FromBitmap(bitmap);
         return bitmapDescriptor;
     }

--- a/lib/Maui.GoogleMaps/Platforms/iOS/Factories/DefaultImageFactory.cs
+++ b/lib/Maui.GoogleMaps/Platforms/iOS/Factories/DefaultImageFactory.cs
@@ -1,18 +1,17 @@
-﻿using Foundation;
-using UIKit;
+﻿using System.Collections.Concurrent;
+using Foundation;
 using Microsoft.Maui.Platform;
-using System.Collections.Concurrent;
+using UIKit;
 
 namespace Maui.GoogleMaps.iOS.Factories;
 
 public sealed class DefaultImageFactory : IImageFactory
 {
-    private static readonly Lazy<DefaultImageFactory> _instance
-        = new Lazy<DefaultImageFactory>(() => new DefaultImageFactory());
+    private static readonly Lazy<DefaultImageFactory> _instance = new(() => new());
 
     public static DefaultImageFactory Instance => _instance.Value;
 
-    private readonly ConcurrentDictionary<string, UIImage> _cacheDictionary = new();
+    private readonly ConcurrentDictionary<string, UIImage> _cacheDictionary = [];
 
     private DefaultImageFactory()
     {
@@ -59,8 +58,7 @@ public sealed class DefaultImageFactory : IImageFactory
 
             case BitmapDescriptorType.View:
                 var iconView = descriptor.View();
-                var nativeView = Utils.ConvertMauiToNative(iconView, mauiContext);
-                var image = Utils.ConvertViewToImage(nativeView);
+                var image = Utils.ConvertMauiViewToImage(iconView, mauiContext);
                 return image;
 
             default:

--- a/lib/Maui.GoogleMaps/Platforms/iOS/GeocoderBackend.cs
+++ b/lib/Maui.GoogleMaps/Platforms/iOS/GeocoderBackend.cs
@@ -33,9 +33,8 @@ internal class GeocoderBackend
         var source = new TaskCompletionSource<IEnumerable<string>>();
         geocoder.ReverseGeocodeLocation(location, (placemarks, error) =>
         {
-            if (placemarks == null)
-                placemarks = new CLPlacemark[0];
-            IEnumerable<string> addresses = placemarks.Select(p => ABAddressFormatting.ToString(p.AddressDictionary, false));
+            placemarks ??= Array.Empty<CLPlacemark>();
+            var addresses = placemarks.Select(p => ABAddressFormatting.ToString(p.AddressDictionary, false));
             source.SetResult(addresses);
         });
         return source.Task;
@@ -48,7 +47,7 @@ internal class GeocoderBackend
         geocoder.GeocodeAddress(address, (placemarks, error) =>
         {
             placemarks ??= Array.Empty<CLPlacemark>();
-            IEnumerable<Position> positions = placemarks.Select(p => new Position(p.Location.Coordinate.Latitude, p.Location.Coordinate.Longitude));
+            var positions = placemarks.Select(p => new Position(p.Location.Coordinate.Latitude, p.Location.Coordinate.Longitude));
             source.SetResult(positions);
         });
         return source.Task;

--- a/lib/Maui.GoogleMaps/Platforms/iOS/MvvmMapHandler.cs
+++ b/lib/Maui.GoogleMaps/Platforms/iOS/MvvmMapHandler.cs
@@ -32,7 +32,7 @@ public partial class MvvmMapHandler : MapHandler
 
         var platformView = view.ToPlatform(Map.Handler.MauiContext);
 
-        var request = view.Measure(this.Map.Width - 50, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+        var request = view.Measure(this.Map.Width - 20, double.PositiveInfinity, MeasureFlags.IncludeMargins);
         view.Layout(new Rect(0, 0, request.Request.Width, request.Request.Height));
 
         platformView.Bounds = view.Bounds;

--- a/lib/Maui.GoogleMaps/Platforms/iOS/Utils.cs
+++ b/lib/Maui.GoogleMaps/Platforms/iOS/Utils.cs
@@ -15,13 +15,13 @@ internal static class Utils
         return view.ToPlatform(mauiContext);
     }
 
-    public static UIImage ConvertViewToImage(UIView view)
+    public static UIImage ConvertMauiViewToImage(View view, IMauiContext mauiContext)
     {
-        UIGraphics.BeginImageContextWithOptions(view.Bounds.Size, false, 0);
-        view.Layer.RenderInContext(UIGraphics.GetCurrentContext());
-        UIImage img = UIGraphics.GetImageFromCurrentImageContext();
-        UIGraphics.EndImageContext();
+        var nativeView = ConvertMauiToNative(view, mauiContext);
 
-        return img;
+        return new UIGraphicsImageRenderer(nativeView.Bounds.Size).CreateImage(ctx =>
+        {
+            nativeView.Layer.RenderInContext(ctx.CGContext);
+        });
     }
 }


### PR DESCRIPTION
Fixed how view converts to image on android and on ios for pins:
- on ios previous method is deprecated from v17
- on android previous method is deprecated from v28

Fixed ScaledDensity on android 
- ScaledDensity changed to Density, since ScaledDensity is deprecated from v34, also GetMetrics() deprecated from v30