### PR TITLE
Fix Runtime Crash on iOS

### DIFF
--- a/lib/Maui.GoogleMaps/Platforms/iOS/Logics/PinLogic.cs
+++ b/lib/Maui.GoogleMaps/Platforms/iOS/Logics/PinLogic.cs
@@ -94,7 +94,10 @@ public class PinLogic : DefaultPinLogic<Marker, MapView>
 
     protected override Marker DeleteNativeItem(Pin outerItem)
     {
-        var nativeMarker = outerItem.NativeObject as Marker;
+        if (outerItem.NativeObject is not Marker nativeMarker)
+        {
+            return null;
+        }
 
         _onMarkerDeleting(outerItem, nativeMarker);
 


### PR DESCRIPTION
Fixes a possible null reference exception crash in iOS related to a missing null check.
This check occurs in the Android version of `PinLogic` but not in the iOS version.