### PR TITLE
Update dependencies and version

### DIFF
--- a/lib/Maui.GoogleMaps.Clustering/Maui.GoogleMaps.Clustering.csproj
+++ b/lib/Maui.GoogleMaps.Clustering/Maui.GoogleMaps.Clustering.csproj
@@ -11,11 +11,10 @@
 	  <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	  <PackageId>Onion.Maui.GoogleMaps.Clustering</PackageId>
 	  <Title>Maui.GoogleMaps.Clustering</Title>
-	  <PackageVersion>6.2.0</PackageVersion>
+	  <PackageVersion>6.3.0</PackageVersion>
 	  <PackageReleaseNotes>
-# 6.2.0 
-- Updated dependencies and migrated to net9.0
-- Bug fixes
+# 6.3.0
+- Updated dependencies
 	  </PackageReleaseNotes>
 	  <Authors>themronion</Authors>
 	  <Copyright>Copyright 2022-2025</Copyright>
@@ -36,7 +35,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.30" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.80" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">

--- a/lib/Maui.GoogleMaps/Maui.GoogleMaps.csproj
+++ b/lib/Maui.GoogleMaps/Maui.GoogleMaps.csproj
@@ -10,11 +10,10 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Onion.Maui.GoogleMaps</PackageId>
 		<Title>Maui.GoogleMaps</Title>
-		<PackageVersion>6.2.0</PackageVersion>
+		<PackageVersion>6.3.0</PackageVersion>
 		<PackageReleaseNotes>
-# 6.2.0
-- Updated dependencies and migrated to net9.0
-- Bug fixes
+# 6.3.0
+- Updated dependencies
 		</PackageReleaseNotes>
 		<Authors>themronion</Authors>
 		<Copyright>Copyright 2022-2025</Copyright>
@@ -35,11 +34,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.30" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.80" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
-		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="119.0.0.4" />
+		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="119.2.0.2" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-ios'">

--- a/sample/MauiGoogleMapSample/MauiGoogleMapSample.csproj
+++ b/sample/MauiGoogleMapSample/MauiGoogleMapSample.csproj
@@ -58,7 +58,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.30" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.80" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Updates to MAUI 9.0.80 SR8
- Update Xamarin.GooglePlayServices.Maps
- Bump version from v6.2.0 to v6.3.0

Tested on Android and works as expected.