### PR TITLE
Update to .NET 10

### DIFF
--- a/lib/Maui.GoogleMaps.Clustering/Maui.GoogleMaps.Clustering.csproj
+++ b/lib/Maui.GoogleMaps.Clustering/Maui.GoogleMaps.Clustering.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Nullable>enable</Nullable>
-	  <TargetFrameworks>net9.0;net9.0-android;net9.0-ios</TargetFrameworks>
+	  <TargetFrameworks>net10.0;net10.0-android;net10.0-ios</TargetFrameworks>
 	  <UseMaui>true</UseMaui>
 	  <SingleProject>true</SingleProject>
 	  <ImplicitUsings>enable</ImplicitUsings>
@@ -11,11 +11,10 @@
 	  <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	  <PackageId>Onion.Maui.GoogleMaps.Clustering</PackageId>
 	  <Title>Maui.GoogleMaps.Clustering</Title>
-	  <PackageVersion>6.3.0</PackageVersion>
+	  <PackageVersion>6.4.0</PackageVersion>
 	  <PackageReleaseNotes>
-# 6.3.0
+# 6.4.0
 - Updated dependencies
-- Fixed ClusteredMap Pin IsVisible Not Working
 	  </PackageReleaseNotes>
 	  <Authors>themronion</Authors>
 	  <Copyright>Copyright 2022-2025</Copyright>
@@ -36,10 +35,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.110" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.10" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' != 'net9.0'">
+	<ItemGroup Condition="'$(TargetFramework)' != 'net10.0'">
 		<PackageReference Include="Xamarin.Google.Maps.Utils" Version="1.3.9" />
 	</ItemGroup>
 

--- a/lib/Maui.GoogleMaps/Maui.GoogleMaps.csproj
+++ b/lib/Maui.GoogleMaps/Maui.GoogleMaps.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net9.0-android;net9.0-ios</TargetFrameworks>
+		<TargetFrameworks>net10.0;net10.0-android;net10.0-ios</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -10,11 +10,10 @@
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<PackageId>Onion.Maui.GoogleMaps</PackageId>
 		<Title>Maui.GoogleMaps</Title>
-		<PackageVersion>6.3.0</PackageVersion>
+		<PackageVersion>6.4.0</PackageVersion>
 		<PackageReleaseNotes>
-# 6.3.0
+# 6.4.0
 - Updated dependencies
-- Support for Custom Dash Thicknesses
 		</PackageReleaseNotes>
 		<Authors>themronion</Authors>
 		<Copyright>Copyright 2022-2025</Copyright>
@@ -35,16 +34,16 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.110" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.10" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-ios'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
 	  <PackageReference Include="AdamE.Google.iOS.Maps" Version="9.2.0.7" />
 	  <PackageReference Include="Xamarin.Build.Download" Version="0.11.4" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
-      <PackageReference Include="Xamarin.AndroidX.SavedState.SavedState.Ktx" Version="1.3.2" />
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
+      <PackageReference Include="Xamarin.AndroidX.SavedState.SavedState.Ktx" Version="1.3.3" />
 	  <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="119.2.0.3" />
 	</ItemGroup>
 

--- a/sample/MauiGoogleMapSample/MauiGoogleMapSample.csproj
+++ b/sample/MauiGoogleMapSample/MauiGoogleMapSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0-android;net9.0-ios</TargetFrameworks>
+		<TargetFrameworks>net10.0-android;net10.0-ios</TargetFrameworks>
 
 		<OutputType>Exe</OutputType>
 		<RootNamespace>MauiGoogleMapSample</RootNamespace>
@@ -24,7 +24,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net9.0-ios'">
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
 		<RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
 	</PropertyGroup>
 
@@ -58,7 +58,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.110" />
+	  <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This PR updates the target framework to .NET 10, and the MAUI dependency to the latest version.

There are several warnings related to deprecated API calls iOS 15 and Android 26 that should be addressed. However, I will keep this PR short and only do the platform upgrade. I might issue another one later with more changes.

I also have a bug related to CircleLogic on iOS that is the reason for me working on this fork. This fix will be issued a separate PR.