### PR TITLE
feat(clustering): optional Android ClusterRenderer factory

### DIFF
--- a/lib/Maui.GoogleMaps.Clustering/AppHostBuilderExtensions.cs
+++ b/lib/Maui.GoogleMaps.Clustering/AppHostBuilderExtensions.cs
@@ -1,9 +1,18 @@
-﻿namespace Maui.GoogleMaps.Clustering.Hosting
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Maui.GoogleMaps.Clustering.Hosting
 {
     public static class AppHostBuilderExtensions
     {
-        public static MauiAppBuilder UseGoogleMapsClustering(this MauiAppBuilder appBuilder)
+        /// <summary>Registers clustering handlers and an optional <see cref="GoogleMapsClusteringOptions"/> instance (singleton).</summary>
+        public static MauiAppBuilder UseGoogleMapsClustering(
+            this MauiAppBuilder appBuilder,
+            Action<GoogleMapsClusteringOptions>? configure = null)
         {
+            var options = new GoogleMapsClusteringOptions();
+            configure?.Invoke(options);
+            appBuilder.Services.AddSingleton(options);
+
 #if ANDROID || IOS
             appBuilder
                 .ConfigureMauiHandlers(handlers =>

--- a/lib/Maui.GoogleMaps.Clustering/GoogleMapsClusteringOptions.cs
+++ b/lib/Maui.GoogleMaps.Clustering/GoogleMapsClusteringOptions.cs
@@ -1,0 +1,8 @@
+namespace Maui.GoogleMaps.Clustering;
+
+/// <summary>
+/// Configuration for Maui.GoogleMaps.Clustering. Use the platform-specific partial for Android options.
+/// </summary>
+public sealed partial class GoogleMapsClusteringOptions
+{
+}

--- a/lib/Maui.GoogleMaps.Clustering/Logics/ClusterOptions.cs
+++ b/lib/Maui.GoogleMaps.Clustering/Logics/ClusterOptions.cs
@@ -42,13 +42,13 @@
         /// Gets or sets the renderer image.
         /// </summary>
         /// <value>The renderer image.</value>
-        internal BitmapDescriptor RendererImage { get; set; }
+        public BitmapDescriptor? RendererImage { get; set; }
 
         /// <summary>
         /// Gets or sets the renderer callback.
         /// </summary>
         /// <value>The renderer callback.</value>
-        internal Func<string, BitmapDescriptor> RendererCallback { get; set; }
+        public Func<string, BitmapDescriptor>? RendererCallback { get; set; }
 
         /// <summary>
         /// Gets or sets the minimum cluster size.

--- a/lib/Maui.GoogleMaps.Clustering/Platforms/Android/ClusterLogic.cs
+++ b/lib/Maui.GoogleMaps.Clustering/Platforms/Android/ClusterLogic.cs
@@ -14,6 +14,7 @@ using Maui.GoogleMaps.Android.Extensions;
 using Maui.GoogleMaps.Android.Factories;
 using Maui.GoogleMaps.Clustering.Logics;
 using Maui.GoogleMaps.Logics;
+using Maui.GoogleMaps.Clustering;
 
 namespace Maui.GoogleMaps.Clustering.Platforms.Android
 {
@@ -40,6 +41,7 @@ namespace Maui.GoogleMaps.Clustering.Platforms.Android
         private ClusterRenderer clusterRenderer;
 
         private readonly Dictionary<string, Pin> itemsDictionary = new Dictionary<string, Pin>();
+        private readonly GoogleMapsClusteringOptions? clusteringOptions;
 
         public ClusterLogic(
             Context context,
@@ -47,7 +49,8 @@ namespace Maui.GoogleMaps.Clustering.Platforms.Android
             Action<Pin, MarkerOptions> onMarkerCreating,
             Action<Pin, ClusteredMarker> onMarkerCreated,
             Action<Pin, ClusteredMarker> onMarkerDeleting,
-            Action<Pin, ClusteredMarker> onMarkerDeleted)
+            Action<Pin, ClusteredMarker> onMarkerDeleted,
+            GoogleMapsClusteringOptions? clusteringOptions = null)
         {
             this.bitmapDescriptorFactory = bitmapDescriptorFactory;
             this.context = context;
@@ -55,6 +58,7 @@ namespace Maui.GoogleMaps.Clustering.Platforms.Android
             this.onMarkerCreated = onMarkerCreated;
             this.onMarkerDeleting = onMarkerDeleting;
             this.onMarkerDeleted = onMarkerDeleted;
+            this.clusteringOptions = clusteringOptions;
         }
 
         public override void Register(GoogleMap oldNativeMap, Map oldMap, GoogleMap newNativeMap, Map newMap, IElementHandler handler)
@@ -91,11 +95,19 @@ namespace Maui.GoogleMaps.Clustering.Platforms.Android
             newNativeMap.MarkerDragEnd += OnMarkerDragEnd;
             newNativeMap.MarkerDrag += OnMarkerDrag;
 
-            clusterRenderer = new ClusterRenderer(context,
-                ClusteredMapp,
-                NativeMap,
-                clusterManager,
-                handler.MauiContext);
+            var createRenderer = clusteringOptions?.CreateAndroidClusterRenderer;
+            clusterRenderer = createRenderer?.Invoke(new AndroidClusterRendererCreateContext(
+                    context,
+                    ClusteredMapp,
+                    NativeMap,
+                    clusterManager,
+                    handler.MauiContext))
+                ?? new ClusterRenderer(
+                    context,
+                    ClusteredMapp,
+                    NativeMap,
+                    clusterManager,
+                    handler.MauiContext);
             clusterManager.Renderer = clusterRenderer;
 
             clusterManager.SetOnClusterClickListener(clusterListener);

--- a/lib/Maui.GoogleMaps.Clustering/Platforms/Android/ClusterMapHandler.cs
+++ b/lib/Maui.GoogleMaps.Clustering/Platforms/Android/ClusterMapHandler.cs
@@ -7,6 +7,7 @@ using Android.Gms.Maps.Utils.Data.GeoJson;
 using Maui.GoogleMaps.Clustering.Platforms.Android;
 using Maui.GoogleMaps.Logics;
 using Maui.GoogleMaps.Logics.Android;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Maui.GoogleMaps.Clustering
 {
@@ -64,15 +65,26 @@ namespace Maui.GoogleMaps.Clustering
             base.OnMapReady();
             var cluster = VirtualView as ClusteredMap;
         }
-        public override void InitLogics() => Logics = new List<BaseLogic<GoogleMap>>
+        public override void InitLogics()
         {
-            new PolylineLogic(),
-            new PolygonLogic(),
-            new CircleLogic(),
-            new ClusterLogic(this.Context, Config.GetBitmapdescriptionFactory(), OnClusteredMarkerCreating, OnClusteredMarkerCreated, OnClusteredMarkerDeleting, OnClusteredMarkerDeleted),
-            new TileLayerLogic(),
-            new GroundOverlayLogic(Config.GetBitmapdescriptionFactory())
-        };
+            var clusteringOptions = MauiContext?.Services.GetService<GoogleMapsClusteringOptions>();
+            Logics = new List<BaseLogic<GoogleMap>>
+            {
+                new PolylineLogic(),
+                new PolygonLogic(),
+                new CircleLogic(),
+                new ClusterLogic(
+                    Context,
+                    Config.GetBitmapdescriptionFactory(),
+                    OnClusteredMarkerCreating,
+                    OnClusteredMarkerCreated,
+                    OnClusteredMarkerDeleting,
+                    OnClusteredMarkerDeleted,
+                    clusteringOptions),
+                new TileLayerLogic(),
+                new GroundOverlayLogic(Config.GetBitmapdescriptionFactory())
+            };
+        }
 
     }   
 }

--- a/lib/Maui.GoogleMaps.Clustering/Platforms/Android/ClusterRenderer.cs
+++ b/lib/Maui.GoogleMaps.Clustering/Platforms/Android/ClusterRenderer.cs
@@ -46,7 +46,6 @@ namespace Maui.GoogleMaps.Clustering.Platforms.Android
             marker.Rotation = clusteredMarker.Rotation;
             marker.Visible = clusteredMarker.Visible;
             marker.SetAnchor(clusteredMarker.AnchorX, clusteredMarker.AnchorY);
-            //marker.SetInfoWindowAnchor(clusteredMarker.InfoWindowAnchorX, clusteredMarker.InfoWindowAnchorY);
             marker.Flat = clusteredMarker.Flat;
             marker.Alpha = clusteredMarker.Alpha;
             marker.SetIcon(clusteredMarker.Icon);
@@ -56,7 +55,8 @@ namespace Maui.GoogleMaps.Clustering.Platforms.Android
         {
             if (map.ClusterOptions.RendererCallback != null)
             {
-                var descriptorFromCallback = map.ClusterOptions.RendererCallback(map.ClusterOptions.EnableBuckets ? GetClusterText(cluster) : cluster.Size.ToString());
+                var descriptorFromCallback = map.ClusterOptions.RendererCallback(
+                    map.ClusterOptions.EnableBuckets ? GetClusterText(cluster) : cluster.Size.ToString());
 
                 options.SetIcon(GetIcon(cluster, descriptorFromCallback));
             }
@@ -70,7 +70,7 @@ namespace Maui.GoogleMaps.Clustering.Platforms.Android
             }
         }
 
-        private NativeBitmapDescriptor GetIcon(ICluster cluster, BitmapDescriptor descriptor)
+        private NativeBitmapDescriptor GetIcon(ICluster cluster, Maui.GoogleMaps.BitmapDescriptor descriptor)
         {
             var clusterText = GetClusterText(cluster);
 
@@ -112,7 +112,6 @@ namespace Maui.GoogleMaps.Clustering.Platforms.Android
                 .Draggable(clusteredMarker.Draggable)
                 .SetRotation(clusteredMarker.Rotation)
                 .Anchor(clusteredMarker.AnchorX, clusteredMarker.AnchorY)
-                //  .InfoWindowAnchor(clusteredMarker.InfoWindowAnchorX, clusteredMarker.InfoWindowAnchorY)
                 .SetAlpha(clusteredMarker.Alpha)
                 .Flat(clusteredMarker.Flat);
 

--- a/lib/Maui.GoogleMaps.Clustering/Platforms/Android/GoogleMapsClusteringOptions.Android.cs
+++ b/lib/Maui.GoogleMaps.Clustering/Platforms/Android/GoogleMapsClusteringOptions.Android.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using Android.Content;
+using Android.Gms.Maps;
+using Android.Gms.Maps.Utils.Clustering;
+using Microsoft.Maui.Platform;
+
+namespace Maui.GoogleMaps.Clustering;
+
+/// <summary>Arguments passed to <see cref="GoogleMapsClusteringOptions.CreateAndroidClusterRenderer"/>.</summary>
+public sealed class AndroidClusterRendererCreateContext
+{
+    public AndroidClusterRendererCreateContext(
+        Context context,
+        ClusteredMap clusteredMap,
+        GoogleMap nativeMap,
+        ClusterManager clusterManager,
+        IMauiContext mauiContext)
+    {
+        Context = context;
+        ClusteredMap = clusteredMap;
+        NativeMap = nativeMap;
+        ClusterManager = clusterManager;
+        MauiContext = mauiContext;
+    }
+
+    public Context Context { get; }
+    public ClusteredMap ClusteredMap { get; }
+    public GoogleMap NativeMap { get; }
+    public ClusterManager ClusterManager { get; }
+    public IMauiContext MauiContext { get; }
+}
+
+public sealed partial class GoogleMapsClusteringOptions
+{
+    /// <summary>
+    /// Optional factory for the Android cluster renderer. When null, the default <see cref="Platforms.Android.ClusterRenderer"/> is used.
+    /// </summary>
+    public Func<AndroidClusterRendererCreateContext, Platforms.Android.ClusterRenderer>? CreateAndroidClusterRenderer { get; set; }
+}


### PR DESCRIPTION
### Summary
Adds an extension point so apps can supply their own Android ClusterRenderer. Registers GoogleMapsClusteringOptions in DI and wires it from ClusterMapHandler → ClusterLogic. Exposes ClusterOptions.RendererCallback and RendererImage as public (nullable) so custom renderers in consuming apps can read them.

### Motivation
ClusterLogic always instantiated the built-in ClusterRenderer. Any behavior that depends on how cluster text is passed into SetRenderUsingCustomAction, or how cluster markers are updated on the native map, required forking or copying the library. This change keeps the default path unchanged when CreateAndroidClusterRenderer is not set.

### What changed
UseGoogleMapsClustering(Action<GoogleMapsClusteringOptions>? configure = null) — optional callback; registers a singleton GoogleMapsClusteringOptions.
AndroidClusterRendererCreateContext + CreateAndroidClusterRenderer factory.
ClusterLogic / ClusterMapHandler (Android): resolve options from MauiContext.Services and use factory when non-null; otherwise new ClusterRenderer(...).
ClusterOptions: RendererCallback and RendererImage are public and nullable (for custom renderers outside the assembly).

### Breaking changes
None intended: existing builder.UseGoogleMapsClustering() without arguments behaves as before. Making RendererCallback / RendererImage public widens API surface only.

### How to test
Build Maui.GoogleMaps.Clustering for net10.0-android.
Smoke-test sample app with default UseGoogleMapsClustering().
(Optional) Local app with CreateAndroidClusterRenderer returning a ClusterRenderer subclass.